### PR TITLE
doc: update the git URL to clone in order to install the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The primary goal of this project, beyond just being a lot of fun to work on, is 
 ### Clone repo and Install packages
 
 ```bash
-git clone git@github.com:a16z-infra/ai-town.git
+git clone https://github.com/a16z-infra/ai-town
 cd AI-town
 npm install
 npm run dev


### PR DESCRIPTION
The previous cloning instruction fails because it requires to have a public key authorized (e.g. `git@github.com: Permission denied (publickey).`)